### PR TITLE
Make Tracking Id Working in Play with MDCPropagatingDispatcher and Injected ExecutionContext

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -5,8 +5,7 @@ import javax.inject._
 import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 
 /**
@@ -14,7 +13,9 @@ import scala.concurrent.Future
   * application's home page.
   */
 @Singleton
-class HomeController @Inject() extends Controller with LazyLogging {
+class HomeController @Inject() (
+  implicit ec: ExecutionContext
+) extends Controller with LazyLogging {
 
   /**
     * Create an Action to render an HTML page with a welcome message.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -353,12 +353,11 @@ db {
 }
 
 
-play {
-  akka {
-    actor {
-      default-dispatcher {
-        type = "com.github.rishabh9.MDCPropagatingDispatcherConfigurator"
-      }
+
+akka {
+  actor {
+    default-dispatcher {
+      type = "com.github.rishabh9.MDCPropagatingDispatcherConfigurator"
     }
   }
 }


### PR DESCRIPTION
Hi @smur89 ,

I have the same issue with you recently, and I noticed you created an issue in https://github.com/rishabh9/mdc-propagation-dispatcher/issues/1.

I investigated this issue in my owned project, and found the solution. This PR is my solution and it makes the tracking id logged:

```
(Server started, use Ctrl+D to stop and go back to the console...)

2017-07-20 16:01:41,648 [INFO ] [ForkJoinPool-1-worker-1] application                        - - 
ApplicationTimer demo: Starting application at 2017-07-20T08:01:41.640Z.
2017-07-20 16:01:41,782 [INFO ] [application-akka.actor.default-dispatcher-3] a.e.s.Slf4jLogger - - 
Slf4jLogger started
2017-07-20 16:01:41,853 [INFO ] [ForkJoinPool-1-worker-1] p.a.Play                           - - 
Application started (Dev)
2017-07-20 16:01:41,921 [INFO ] [application-akka.actor.default-dispatcher-4] c.HomeController 
9792e0ea-7e93-4b70-b19b-4953fe2d5384 - Logging
2017-07-20 16:01:41,921 [INFO ] [application-akka.actor.default-dispatcher-6] c.HomeController
 23f0443f-9627-48ca-a30a-2d4c2bfff7cc - Logging
2017-07-20 16:01:41,922 [INFO ] [application-akka.actor.default-dispatcher-2] c.HomeController
 9792e0ea-7e93-4b70-b19b-4953fe2d5384 - Logging in the Future!
2017-07-20 16:01:41,922 [INFO ] [application-akka.actor.default-dispatcher-2] c.HomeController
 23f0443f-9627-48ca-a30a-2d4c2bfff7cc - Logging in the Future!
```

The solution has two changes:

* the `default-dispatcher` should be  configured in `akka.actor`, not `play.akka.actor`,
* stop using the `scala.concurrent.ExecutionContext.Implicits.global`

I wrote the details in my post, if you want to read more:

https://scozv.github.io/blog/pattern/2017/07/18/injection-of-tracking-id-to-logback-message-with-customer-dispatcher-and-mapped-diagnostic-contexts-in-scala
